### PR TITLE
New Player collisions, Implemented Movement with acceleration and friction, Better gamepad movement 

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -102,6 +102,8 @@ MonoBehaviour:
   maxSpeed: 8
   acceleration: 100
   friction: 140
+  gamepadDeadzone: 0.05
+  gamepadmaxSpeedThreashold: 0.5
   player: {fileID: 8343199554380001103}
   playerInput: {fileID: 859528782026247002}
   rb: {fileID: 176917095401970236}

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -37,6 +37,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6488318111509589437}
+  - {fileID: 8276928899600107017}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &859528782026247002
@@ -81,7 +82,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47726edfc47ebb5429e2d28ca8217a33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  insideInteractable: {fileID: 0}
   playerInput: {fileID: 859528782026247002}
   playerTeam: {fileID: 4720667436485828352}
   playerControlBadge: {fileID: 5167199617259306430}
@@ -175,7 +175,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -349,6 +349,74 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!1 &6025645069762242533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8276928899600107017}
+  - component: {fileID: 1464820862654206432}
+  m_Layer: 6
+  m_Name: CollisionCircle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8276928899600107017
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6025645069762242533}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4006656927875155964}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &1464820862654206432
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6025645069762242533}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.5
 --- !u!1001 &3055710517671957049
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -470,6 +538,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6488318111509589437}
     m_Modifications:
+    - target: {fileID: 311872216489952383, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 350535946810898002, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 633610853135955996, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -484,12 +560,28 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 633610853135955996, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1306481334988066537, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1433744196269100742, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1777358524332453278, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
       propertyPath: m_Name
       value: PlayerControllerBadge
       objectReference: {fileID: 0}
+    - target: {fileID: 1777358524332453278, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1957006551524067562, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2619411725181104286, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -504,6 +596,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2619411725181104286, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673144257944599835, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2828558726226557837, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
@@ -586,6 +682,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2934415890681821891, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3863563406839920944, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3895623661270033655, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
       propertyPath: player
       value: 
@@ -594,6 +698,74 @@ PrefabInstance:
       propertyPath: playerTeam
       value: 
       objectReference: {fileID: 4720667436485828352}
+    - target: {fileID: 4030077082580419496, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4194269546331973712, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4391402698875076830, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4551392757767355221, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653264549600356322, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5309453904940665509, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5765944297760505085, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6225019095476822809, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7113169263539599309, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215918055651252098, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7397512523854644250, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7437948822101210429, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615261420674204204, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945299527007250901, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8326511394360499217, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8862883221197643422, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9084902762258511847, guid: 0e1cc938fb0660c4882df5e0bc4657e2, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -99,7 +99,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ba2a6933f5869544693a019bbe8eb80d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 7
+  maxSpeed: 8
+  acceleration: 100
+  friction: 140
   player: {fileID: 8343199554380001103}
   playerInput: {fileID: 859528782026247002}
   rb: {fileID: 176917095401970236}

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -4,7 +4,9 @@ using UnityEngine.InputSystem;
 public class PlayerMovement : MonoBehaviour
 {
     [Header("Movement")]
-    [SerializeField] private float speed = 7f;
+    [SerializeField] private float maxSpeed = 8f;
+    [SerializeField] private float acceleration = 100f;
+    [SerializeField] private float friction = 140f;
 
     [Header("References")]
     [SerializeField] private Player player;
@@ -25,7 +27,40 @@ public class PlayerMovement : MonoBehaviour
             rb.linearVelocity = Vector2.zero;
             return;
         }
-        
-        rb.linearVelocity = moveAction.ReadValue<Vector2>() * speed;
+
+        rb.linearVelocity = VelocityApproach();
+    }
+
+
+    //this is adapted from code from Unnamed check it out on https://fypur.itch.io/unnamed (tsais le mec qui fait sa pub sans aucune honte)
+    /// <summary>
+    /// Make your character accelerate or use friction depending on player input and current speed
+    /// </summary>
+    private Vector2 VelocityApproach()
+    {
+        Vector2 move = moveAction.ReadValue<Vector2>();
+
+        //We wanna move and we're not at top speed -> accelerate
+        if (move != Vector2.zero && rb.linearVelocity.sqrMagnitude < maxSpeed * maxSpeed)
+        {
+            //Account for the fact that move can be of norm different than one (for controllers when moving slowly)
+            Vector2 apporached = (move.sqrMagnitude > 0.3f * 0.3f ? move.normalized : move) * maxSpeed;
+            return Approach(rb.linearVelocity, apporached, acceleration * Time.deltaTime);
+        }
+
+        //We don't wanna move or we're at max speed -> friction (friction is just reverse acceleration, it's not a multiple of velocity)
+        return Approach(rb.linearVelocity, Vector2.zero, friction * Time.deltaTime);
+    }
+
+    /// <summary>
+    /// Returns approached version of <paramref name="value"/> towards <paramref name="approached"/> with a step size of <paramref name="move"/>
+    /// </summary>
+    private Vector2 Approach(Vector2 value, Vector2 approached, float move)
+    {
+        Vector2 dir = (approached - value);
+        float maxDisplacement = dir.magnitude;
+        dir.Normalize();
+
+        return value + dir * Mathf.Min(maxDisplacement, move);
     }
 }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -7,6 +7,8 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField] private float maxSpeed = 8f;
     [SerializeField] private float acceleration = 100f;
     [SerializeField] private float friction = 140f;
+    [SerializeField] private float gamepadDeadzone = 0.05f;
+    [SerializeField] private float gamepadmaxSpeedThreashold = 0.5f;
 
     [Header("References")]
     [SerializeField] private Player player;
@@ -41,10 +43,10 @@ public class PlayerMovement : MonoBehaviour
         Vector2 move = moveAction.ReadValue<Vector2>();
 
         //We wanna move and we're not at top speed -> accelerate
-        if (move != Vector2.zero && rb.linearVelocity.sqrMagnitude < maxSpeed * maxSpeed)
+        if (move.sqrMagnitude > gamepadDeadzone * gamepadDeadzone && rb.linearVelocity.sqrMagnitude < maxSpeed * maxSpeed)
         {
             //Account for the fact that move can be of norm different than one (for controllers when moving slowly)
-            Vector2 apporached = (move.sqrMagnitude > 0.3f * 0.3f ? move.normalized : move) * maxSpeed;
+            Vector2 apporached = (move.sqrMagnitude > gamepadmaxSpeedThreashold * gamepadmaxSpeedThreashold ? move.normalized : move) * maxSpeed;
             return Approach(rb.linearVelocity, apporached, acceleration * Time.deltaTime);
         }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -2,7 +2,7 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!78 &1
 TagManager:
-  serializedVersion: 2
+  serializedVersion: 3
   tags: []
   layers:
   - Default
@@ -11,7 +11,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - Player
   - 
   - 
   - 
@@ -41,3 +41,5 @@ TagManager:
   - name: Default
     uniqueID: 0
     locked: 0
+  m_RenderingLayers:
+  - Default


### PR DESCRIPTION
I think the code is pretty self explanatory for most of it.
Some key details:
For the gamepad movement, there's a deadzone (no movement, important for stick drifting) and a threashold after which we ignore the gamepad non normalized movement and just pretend the stick is fully flicked (for better feel and not to make kinda broken gamepads slower).
The player's ACTUAL collision is now a circle collider and is on the "Player" layer -> useful later for handling collision matrices. It's also therefore on a different object than the player. This also lets me leave a box collider on the actual parent player object, set as trigger so that it doesn't collide with anything, but (suprisingly) still lets me interact with interactables. Therefore the collision for interacting is a box, which is bigger and better than the circle collider actually used for collisions.