### PR TITLE
Fixed missing workbench sprite renderer.

### DIFF
--- a/Assets/Prefabs/Interactables/Workbench.prefab
+++ b/Assets/Prefabs/Interactables/Workbench.prefab
@@ -49,6 +49,7 @@ MonoBehaviour:
   putOrPickUpItemInteractionTime: 0
   cutWoodInteractionTime: 1
   woodPlankItemPrefab: {fileID: 3378557466002707279, guid: 41bd7609910bc2e4383d0234046cf75a, type: 3}
+  spriteRenderer: {fileID: 4097081278808117934}
 --- !u!61 &8837958186719799260
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Interactable/Workbench.cs
+++ b/Assets/Scripts/Interactable/Workbench.cs
@@ -2,23 +2,17 @@ using UnityEngine;
 
 public class Workbench : Interactable
 {
-    
     private State state;
-    private SpriteRenderer spriteRenderer;
 
     [SerializeField] private float putOrPickUpItemInteractionTime = 0f;
     [SerializeField] private float cutWoodInteractionTime = 1f;
     private float currentInteractionTime;
 
-    [Header("Prefab refs")]
+    [Header("References")]
     [SerializeField] private Item woodPlankItemPrefab;
+    [SerializeField] private SpriteRenderer spriteRenderer;
 
     private enum State { Empty, HasWoodLog, HasWoodPlank }
-
-    private void Awake()
-    {
-        spriteRenderer = GetComponent<SpriteRenderer>();
-    }
 
     public override bool CanInteract(Player player)
     {
@@ -43,19 +37,18 @@ public class Workbench : Interactable
                 state = State.HasWoodLog;
                 player.ConsumeCurrentItem();
                 currentInteractionTime = cutWoodInteractionTime;
-
                 spriteRenderer.color = Color.red;
                 break;
+            
             case State.HasWoodLog:
                 state = State.HasWoodPlank;
                 currentInteractionTime = putOrPickUpItemInteractionTime;
-
                 spriteRenderer.color = Color.blue;
                 break;
+            
             case State.HasWoodPlank:
                 state = State.Empty;
                 player.GrabNewItem(woodPlankItemPrefab);
-
                 spriteRenderer.color = Color.white;
                 break;
         }


### PR DESCRIPTION
A tiny PR to fix the workbench SpriteRenderer (`Missing Reference Exception`)...
... And a lesson why we prefer NOT using GetComponent.
Because when you modify the view - like we did when integrating the assets for the workbench,
everything breaks.
With serialized variables, when you modify where a sprite is located, you can easily tell the inspector where the new sprite is located, without making changes to the actual code.
So when using GetComponent you will very probably have to do these tiny refactors like this one all the time, which is not a big deal but slightly annoying.