### PR TITLE
[DEBATABLE] Re-allowed building enemy tower.

### DIFF
--- a/Assets/Scripts/Interactable/Tower/Tower.cs
+++ b/Assets/Scripts/Interactable/Tower/Tower.cs
@@ -72,9 +72,8 @@ public class Tower : Interactable
     {
         if (!LevelManager.InGame)
             return false;
-        // Check if the player is holding the correct item for the recipe
-        bool playerIsCorrectTeam = player.PlayerTeam.CurrentTeam == PlayerTeam.Team.Left ? IsLeftTower : !IsLeftTower;
-        return player.IsHolding && playerIsCorrectTeam;
+        
+        return player.IsHolding;
     }
 
     public bool IsItemCorrect(Item item) => RecipesList.CurrentNeededItemType == item.ItemType;


### PR DESCRIPTION
Le fait de jeter les items introduit une sorte de "bug" mais pas vraiment un bug.

En gros si t'essaies de construire chez l'ennemi ça marche maintenant.

Mais on peut rien faire vu que de toute manière on peut jeter les items.

Mais on dirait un peu une sorte de bug, si tu vas construire chez l'ennemi ça se highlight pas mais tu peux quand même construire.

Je me demande si à ce stade on devrait pas simplement ré-autoriser la construction chez l'ennemi (en d'autre terme juste ajouter le highlight), au moins ça ne semble pas un bug même si les joueurs n'ont aucun intérêt à le faire.

Donc c'est debatable - ON N'EST PAS OBLIGE DE MERGE CETTE PR !