### PR TITLE
Drop de l'item derrière la tour

### DIFF
--- a/Assets/Scripts/Interactable/Tower/TowerPiece.cs
+++ b/Assets/Scripts/Interactable/Tower/TowerPiece.cs
@@ -3,7 +3,11 @@ public class TowerPiece : Interactable
     private Tower tower;
     public override bool CanInteract(Player player) => tower.CanInteract(player);
 
-    public override void Interact(Player player) => tower.Interact(player);
+    public override void Interact(Player player)
+    {
+        tower.Interact(player);
+        player.DropHeldItem();
+    }
 
     public override float GetInteractionTime() => 0;
 


### PR DESCRIPTION
Le joueur drop l'item si ce n'est pas le bon derière la tour et ça previent que ce n'est pas le bon item sur la tour.

Je sais pas si c'est mieux de prevenir que c'est pas le bon item et drop ou just drop. Pour moi prevenir que c'est pas le bon c'est mieux pour comprendre

Sinon il met la pièce