### PR TITLE
Fix le four qui ne reset pas

### DIFF
--- a/Assets/Scripts/Interactable/Furnace/Furnace.cs
+++ b/Assets/Scripts/Interactable/Furnace/Furnace.cs
@@ -79,10 +79,10 @@ public class Furnace : Interactable
             t += Time.deltaTime;
             yield return null;
         }
-        progressBar.SetProgressMax();
 
         if (state == State.Cooking)
         {
+            progressBar.SetProgressMax();
             SoundManager.instance.StopSound(index);
             state = State.Cooked;
         }   

--- a/Assets/Scripts/Interactable/Furnace/Furnace.cs
+++ b/Assets/Scripts/Interactable/Furnace/Furnace.cs
@@ -18,7 +18,12 @@ public class Furnace : Interactable
 
     public event Action StartedCooking;
     public event Action StoppedCooking;
-
+    
+    protected override void OnGameAboutToStart()
+    {
+        base.OnGameAboutToStart();
+        state = State.Empty;
+    }
     public override bool CanInteract(Player player)
     {
         if (!LevelManager.InGame)
@@ -86,7 +91,6 @@ public class Furnace : Interactable
     protected override void OnGameEnded()
     {
         base.OnGameEnded();
-        state = State.Empty;
         StopCooking();
     }
 

--- a/Assets/Scripts/Interactable/Furnace/Furnace.cs
+++ b/Assets/Scripts/Interactable/Furnace/Furnace.cs
@@ -58,7 +58,6 @@ public class Furnace : Interactable
 
     public override float GetInteractionTime() => 0;
 
-
     public IEnumerator Cook()
     {
         StartedCooking?.Invoke();
@@ -87,11 +86,9 @@ public class Furnace : Interactable
             state = State.Cooked;
         }
         else
-        {
             progressBar.ResetProgress();
-        }
 
-            StopCooking();
+        StopCooking();
     }
     
     protected override void OnGameEnded()

--- a/Assets/Scripts/Interactable/Furnace/Furnace.cs
+++ b/Assets/Scripts/Interactable/Furnace/Furnace.cs
@@ -19,11 +19,6 @@ public class Furnace : Interactable
     public event Action StartedCooking;
     public event Action StoppedCooking;
     
-    protected override void OnGameAboutToStart()
-    {
-        base.OnGameAboutToStart();
-        state = State.Empty;
-    }
     public override bool CanInteract(Player player)
     {
         if (!LevelManager.InGame)
@@ -76,22 +71,29 @@ public class Furnace : Interactable
 
         while (t < cookTime)
         {
+            if (state != State.Cooking)
+                break;
+            
             progressBar.UpdateProgress(t / cookTime);
 
             t += Time.deltaTime;
             yield return null;
         }
         progressBar.SetProgressMax();
-        state = State.Cooked;
 
-        SoundManager.instance.StopSound(index);
+        if (state == State.Cooking)
+        {
+            SoundManager.instance.StopSound(index);
+            state = State.Cooked;
+        }   
+
         StopCooking();
     }
     
     protected override void OnGameEnded()
     {
         base.OnGameEnded();
-        StopCooking();
+        state = State.Empty;
     }
 
     private void StopCooking()

--- a/Assets/Scripts/Interactable/Furnace/Furnace.cs
+++ b/Assets/Scripts/Interactable/Furnace/Furnace.cs
@@ -85,9 +85,13 @@ public class Furnace : Interactable
             progressBar.SetProgressMax();
             SoundManager.instance.StopSound(index);
             state = State.Cooked;
-        }   
+        }
+        else
+        {
+            progressBar.ResetProgress();
+        }
 
-        StopCooking();
+            StopCooking();
     }
     
     protected override void OnGameEnded()


### PR DESCRIPTION
J'ai étudié le problème cela vient de la coroutine Cook() qui ne se termine pas avant la fin du jeu donc l'etat du four est mis à empty dans OnGameEnd() puis remis à cook du à la coroutine Cook() qui se finit après

J'ai deux manière de régler :
*soit comme ici je reset le four au debut de partie qui est un moyen de contourner le bug car le menu de fin prend plus de temps que la cuisson dans le four donc quand je relance la partie dans tous les cas la coroutine Cook aura finit -> moyen rapide efficace mais qui n'ai juste qu'un moyen de contourner le bug 
*Resoudre vraiment le bug en essayant d'avorter la Coroutine avant sa fin (faudrait que je regarde comment faire), plus chiant mais regle le problème à vie.