### PR TITLE
Fix/throw item on interacting player

### DIFF
--- a/Assets/Scripts/Player/PlayerItemCatcher.cs
+++ b/Assets/Scripts/Player/PlayerItemCatcher.cs
@@ -7,6 +7,9 @@ public class PlayerItemCatcher : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collider)
     {
+        if (player.Interacting)
+            return;
+        
         if (collider == null || collider.transform.parent == null)
             return;
 

--- a/Assets/Scripts/Player/PlayerItemCatcher.cs
+++ b/Assets/Scripts/Player/PlayerItemCatcher.cs
@@ -9,7 +9,7 @@ public class PlayerItemCatcher : MonoBehaviour
     {
         if (player.Interacting)
             return;
-        
+
         if (collider == null || collider.transform.parent == null)
             return;
 


### PR DESCRIPTION
Résolu le bug rencontré par un playtester :

Quand un cochon récolte une ressource (blé ou bois) et que le coéquipier nous en lance une, on récupère celle du coéquipier puis celle de la récolte
Celle de la récolte est accessible normalement mais celle envoyé reste sur le cochon à tout jamais
<img width="101" height="133" alt="image" src="https://github.com/user-attachments/assets/560b3be1-f48d-4b2a-b9da-39fc614d7bdd" />
