### PR TITLE
Fixed bug where pressing escape would trigger multiple pauses.

### DIFF
--- a/Assets/Scripts/UI/Pause/PauseMenu.cs
+++ b/Assets/Scripts/UI/Pause/PauseMenu.cs
@@ -15,6 +15,7 @@ public class PauseMenu: MonoBehaviour
 	public event Action Resumed;
 
 	public static PauseMenu instance;
+	private bool toggledPauseThisFrame;
 
 	public void Awake()
 	{
@@ -34,8 +35,13 @@ public class PauseMenu: MonoBehaviour
 			SelectFirstSelectable();
 	}
 
+	private void LateUpdate() => toggledPauseThisFrame = false;
+
 	public void TogglePause()
 	{
+		if(toggledPauseThisFrame) return;
+		toggledPauseThisFrame = true;
+
 		if (IsPaused)
 			Resume();
 		else


### PR DESCRIPTION
Fixed bug where pressing escape would trigger the pause menu multiple times, resulting in soundtrack stopping.

This bug was reported on the Discord:

> Maintenant quand j'appuye sur Échap ça coupe carrément la musique et aucun menu d'option n'apparaît 