### PR TITLE
Fixed bug where the player badge fading doesn't work when returning t…

### DIFF
--- a/Assets/Scripts/ControllerConnection/PlayerControlBadge.cs
+++ b/Assets/Scripts/ControllerConnection/PlayerControlBadge.cs
@@ -1,4 +1,5 @@
 using System;
+using LitMotion;
 using UnityEngine;
 using TMPro;
 using UnityEngine.InputSystem;
@@ -54,15 +55,24 @@ public class PlayerControlBadge : MonoBehaviour
         LevelManager.Instance.ReturnedToLobby += OnReturnedToLobby;
     }
 
+    private MotionHandle fadeMotionHandle;
+    
     private void OnGameStarted()
     {
-        FadeInNOutUtility.FadeInOrOut(graphics, LevelManager.Instance.LobbyUIFadeTime, false);
+        Fade(false);
     }
 
     private void OnReturnedToLobby()
     {
         graphics.gameObject.SetActive(true);
-        FadeInNOutUtility.FadeInOrOut(graphics, LevelManager.Instance.LobbyUIFadeTime, true);
+        Fade(true);
+    }
+
+    private void Fade(bool fadeIn)
+    {
+        if (fadeMotionHandle.IsActive())
+            fadeMotionHandle.Cancel();
+        fadeMotionHandle = FadeInNOutUtility.FadeInOrOut(graphics, LevelManager.Instance.LobbyUIFadeTime, fadeIn, fromCurrentValue: true);
     }
 
     private void OnTeamChanged()

--- a/Assets/Scripts/Utilities/FadeInNOutUtility.cs
+++ b/Assets/Scripts/Utilities/FadeInNOutUtility.cs
@@ -1,15 +1,19 @@
 using LitMotion;
-using System;
 using UnityEngine;
 
 public static class FadeInNOutUtility
 {
-    public static async void FadeInOrOut(CanvasGroup canvasGroup, float time, bool fadeIn, bool setActive = true)
-    {
-        if (fadeIn && setActive) canvasGroup.gameObject.SetActive(true);
+	public static MotionHandle FadeInOrOut(CanvasGroup canvasGroup, float time, bool fadeIn, bool setActive = true, bool fromCurrentValue = false)
+	{
+		if (fadeIn && setActive)
+			canvasGroup.gameObject.SetActive(true);
 
-        await LMotion.Create(fadeIn ? 0f : 1f, fadeIn ? 1f : 0f, time).Bind((alpha) => canvasGroup.alpha = alpha);
-
-        if (!fadeIn && setActive) canvasGroup.gameObject.SetActive(false);
-    }
+		return LMotion.Create(fromCurrentValue ? canvasGroup.alpha : fadeIn ? 0f : 1f, fadeIn ? 1f : 0f, time)
+					  .WithOnComplete(() =>
+					  {
+						  if (!fadeIn && setActive)
+							  canvasGroup.gameObject.SetActive(false);
+					  })
+					  .Bind(a => canvasGroup.alpha = a);
+	}
 }


### PR DESCRIPTION
Fixed bug where the player badge fading doesn't work when returning to lobby while the fade is in process.

This bug was reported on our Discord:

"sinon sur l'ancienne version j'avais ce bug mineur
en lançant le jeu et en appuyant sur echap pour ouvrir les options durant le compte à rebours, puis revenir dans le lobby, l'IU dans le lobby disparaît"