### PR TITLE
Fixed bug when trying to throw an item, but holding 2 buttons

### DIFF
--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -151,8 +151,10 @@ public class Player : MonoBehaviour
             ThrowAndExitAim(ThrowVelocity);
             return;
         }
-        
-        if (interactAction.WasReleasedThisFrame())
+
+        // If the player releases the interact button BUT is still holding the throw button at the same time,
+        // their intention is probably to throw the item, so we should not drop it and stay in the StartingToAim state.
+        if (interactAction.WasReleasedThisFrame() && !throwAction.IsPressed())
         {
             ThrowAndExitAim();
             return;


### PR DESCRIPTION
Fixed bug when trying to throw an item, but holding 2 buttons at the same time.

This bug mainly happens with the keyboard when switching between interact and throw rapidly.
Bug reported by @Fypur 


Etapes de reproduction du bug (résolu sur cette PR) :

1.  Maintenir E sur la resource. Au bout d'un moment la resource se farm.
2. Commencer à appuyer sur A.
3. AVANT DE RELACHER A, relâché E. Alors là c'est pas lancé.

(Le jeu détecte qu'on a relâché E qui est la touche de drop donc il drop sans lancer.)